### PR TITLE
Structure Changes

### DIFF
--- a/Persona3reload/calendar-p3r.html
+++ b/Persona3reload/calendar-p3r.html
@@ -4,43 +4,24 @@
     <title>Persona 3 Reload Calendar</title>
     <link href="/css/p3r-calendar-page.css" rel="stylesheet" />
   </head>
-
-  <main>
-    <header>
-      <!-- Need a header image-->
-      <!--<h1><a href=""><img src="" alt=""/></a></h1>-->
-      <h1>Persona 3 Reload: Calendar</h1>
-    </header>
-    <nav>
-      <h3>
-        <a href="/Persona3reload/calendar/4-april-p3r.html">April</a>
-      </h3>
-      <h3>
-        <a href="/Persona3reload/calendar/5-may-p3r.html">May</a>
-      </h3>
-      <h3>
-        <a href="/Persona3reload/calendar/6-june-p3r.html">June</a>
-      </h3>
-      <h3>
-        <a href="/Persona3reload/calendar/7-july-p3r.html">July</a>
-      </h3>
-      <h3>
-        <a href="">August</a>
-      </h3>
-      <h3>
-        <a href="">September</a>
-      </h3>
-      <h3><a href="">October</a></h3>
-      <h3>
-        <a href="">November</a>
-      </h3>
-      <h3>
-        <a href="">December</a>
-      </h3>
-      <h3><a href="">January</a></h3>
-      <h3>
-        <a href="">February</a>
-      </h3>
-    </nav>
-  </main>
+  <body>
+    <main>
+      <header>
+        <h1>Persona 3 Reload: Calendar</h1>
+      </header>
+      <nav>
+        <h3><a href="/Persona3reload/calendar/4-april-p3r.html">April</a></h3>
+        <h3><a href="/Persona3reload/calendar/5-may-p3r.html">May</a></h3>
+        <h3><a href="/Persona3reload/calendar/6-june-p3r.html">June</a></h3>
+        <h3><a href="/Persona3reload/calendar/7-july-p3r.html">July</a></h3>
+        <h3><a href="">August</a></h3>
+        <h3><a href="">September</a></h3>
+        <h3><a href="">October</a></h3>
+        <h3><a href="">November</a></h3>
+        <h3><a href="">December</a></h3>
+        <h3><a href="">January</a></h3>
+        <h3><a href="">February</a></h3>
+      </nav>
+    </main>
+  </body>
 </html>

--- a/Persona3reload/calendar/4-april-p3r.html
+++ b/Persona3reload/calendar/4-april-p3r.html
@@ -1,430 +1,485 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <!--<link
+
+<head>
+  <!--<link
       href="/css/fonts/bubblegum-superstar.ttf"
       rel="stylesheet"
       type="text/css"
     />-->
-    <link href="/css/p3r-months.css" rel="stylesheet">
-    <title>Calendar: April(Persona 4 Reload)</title>
-  </head>
-  <main>
-    <header>
-      <h1>
-        <u>April</u>
-      </h1>
-      <nav>
-        <ul id="main_menu_setup" class="main_menu_style">
-          <li><a href="/Persona3reload/persona3reload.html">Home</a></li>
-          <li><a href="/Persona3reload/calendar-p3r.html">Month</a></li>
-        </ul>
-      </nav>
+  <link href="/css/p3r-months.css" rel="stylesheet">
+  <script src="/js/progress-tracking.js" defer></script>
+  <title>Calendar: April(Persona 4 Reload)</title>
+</head>
+<main>
+  <header>
+    <h1>
+      <u>April</u>
+    </h1>
+    <nav>
+      <ul id="main_menu_setup" class="navbar">
+        <li><a href="/Persona3reload/persona3reload.html">Home</a></li>
+        <li><a href="/Persona3reload/calendar-p3r.html">Month</a></li>
+      </ul>
+    </nav>
 
-      <nav>
-        <table class="cal_nav_border" id="cal_nav">
-          <thead>
-            <tr>
-              <th class="cal_nav_th_font">Sun</th>
-              <th class="cal_nav_th_font">Mon</th>
-              <th class="cal_nav_th_font">Tue</th>
-              <th class="cal_nav_th_font">Wed</th>
-              <th class="cal_nav_th_font">Thur</th>
-              <th class="cal_nav_th_font">Fri</th>
-              <th class="cal_nav_th_font">Sat</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="cal_nav_font"></td>
-              <td class="cal_nav_font"></td>
-              <td class="cal_nav_font"></td>
-              <td class="cal_nav_font">1</td>
-              <td class="cal_nav_font">2</td>
-              <td class="cal_nav_font">3</td>
-              <td class="cal_nav_font">4</td>
-            </tr>
-            <tr>
-              <td class="cal_nav_font">5</td>
-              <td class="cal_nav_font"><a href="#p3r-april-6">6</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-7">7</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-8">8</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-9">9</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-10">10</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-11">11</a></td>
-            </tr>
-            <tr>
-              <td class="cal_nav_font"><a href="#p3r-april-12">12</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-13">13</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-14">14</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-15">15</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-16">16</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-17">17</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-18">18</a></td>
-            </tr>
-            <tr>
-              <td class="cal_nav_font"><a href="#p3r-april-19">19</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-20">20</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-21">21</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-22">22</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-23">23</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-24">24</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-25">25</a></td>
-            </tr>
-            <tr>
-              <td class="cal_nav_font"><a href="#p3r-april-26">26</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-27">27</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-28">28</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-29">29</a></td>
-              <td class="cal_nav_font"><a href="#p3r-april-30">30</a></td>
-              <td class="cal_nav_font"><a href=""></a></td>
-              <td class="cal_nav_font"><a href=""></a></td>
-            </tr>
-          </tbody>
-        </table>
-      </nav>
-    </header>
+    <nav>
+      <table class="cal_nav_border" id="cal_nav">
+        <thead>
+          <tr>
+            <th class="cal_nav_th_font">Sun</th>
+            <th class="cal_nav_th_font">Mon</th>
+            <th class="cal_nav_th_font">Tue</th>
+            <th class="cal_nav_th_font">Wed</th>
+            <th class="cal_nav_th_font">Thur</th>
+            <th class="cal_nav_th_font">Fri</th>
+            <th class="cal_nav_th_font">Sat</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="cal_nav_font"></td>
+            <td class="cal_nav_font"></td>
+            <td class="cal_nav_font"></td>
+            <td class="cal_nav_font">1</td>
+            <td class="cal_nav_font">2</td>
+            <td class="cal_nav_font">3</td>
+            <td class="cal_nav_font">4</td>
+          </tr>
+          <tr>
+            <td class="cal_nav_font">5</td>
+            <td class="cal_nav_font"><a href="#p3r-april-6">6</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-7">7</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-8">8</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-9">9</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-10">10</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-11">11</a></td>
+          </tr>
+          <tr>
+            <td class="cal_nav_font"><a href="#p3r-april-12">12</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-13">13</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-14">14</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-15">15</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-16">16</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-17">17</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-18">18</a></td>
+          </tr>
+          <tr>
+            <td class="cal_nav_font"><a href="#p3r-april-19">19</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-20">20</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-21">21</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-22">22</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-23">23</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-24">24</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-25">25</a></td>
+          </tr>
+          <tr>
+            <td class="cal_nav_font"><a href="#p3r-april-26">26</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-27">27</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-28">28</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-29">29</a></td>
+            <td class="cal_nav_font"><a href="#p3r-april-30">30</a></td>
+            <td class="cal_nav_font"><a href=""></a></td>
+            <td class="cal_nav_font"><a href=""></a></td>
+          </tr>
+        </tbody>
+      </table>
+    </nav>
+  </header>
 
-    <section id="content-days">
-      <section>
-        <h3 class="" id="p3r-april-6">Monday April 6</h3>
-        <p>Nothing</p>
-      </section>
+  <section id="content-days">
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-6">Monday April 6</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-7">Tuesday April 7</h3>
-        <p>Nothing</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-7">Tuesday April 7</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-8">Wednesday April 8</h3>
-        <h4>[Afternoon]</h4>
-        <p>Teacher Question:</p>
-        <p>Vivid carp streamers</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-8">Wednesday April 8</h3>
+      <h4>[Afternoon]</h4>
+      <p>Teacher Question:</p>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-8-1" data-id="p3r-april-8-1">
+      <label for="p3r-april-8-1">Answer: Vivid carp streamers</label>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-9">Thursday April 9</h3>
-        <h4>[Morning]</h4>
-        <p>During Class:</p>
-        <p>Stay Awake</p>
-      </section>
 
-      <section>
-        <h3 class="" id="p3r-april-10">Friday April 10</h3>
-       <p>Nothing</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-9">Thursday April 9</h3>
+      <h4>[Morning]</h4>
+      <p>During Class:</p>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-9-1" data-id="p3r-april-9-1">
+      <label for="p3r-april-9-1">Stay Awake</label>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-11">Saturday April 11</h3>
-        <p>Nothing</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-10">Friday April 10</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-12">Sunday April 12</h3>
-        <p>Nothing</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-11">Saturday April 11</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-13">Monday April 13</h3>
-        <p>Nothing</p>
-      </section>
 
-      <section>
-        <h3 class="" id="p3r-april-14">Tuesday April 14</h3>
-        <p>Nothing</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-12">Sunday April 12</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-15">Wednesday April 15</h3>
-        <p>Nothing</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-13">Monday April 13</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-16">Thursday April 16</h3>
-        <p>Nothing</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-14">Tuesday April 14</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-17">Friday April 17</h3>
-        <p>Nothing</p>
-      </section>
 
-      <section>
-        <h3 class="" id="p3r-april-18">Saturday April 18</h3>
-        <h4>[Afternoon]</h4>
-        <p>Teacher Question:</p>
-        <p>Middens</p>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-15">Wednesday April 15</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-        <h4>[Evening]</h4>
-        <p>Social Link Fool Rank 1 [Automatic]
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-16">Thursday April 16</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-19">Sunday April 19</h3>
-        <p>Nothing</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-17">Friday April 17</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-20">Monday April 20</h3>
-        <h4>[Dark Hour]</h4>
-        <p>After Tartarus Tutorial: Social Link Fool Rank 2 [Automatic]</p>
-      </section>
 
-      <section>
-        <h3 class="" id="p3r-april-21">Tuesday April 21</h3>
-        <h4>[Afternoon]</h4>
-        <p>During Class:</p>
-        <p>Stay Awake</p>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-18">Saturday April 18</h3>
+      <h4>[Afternoon]</h4>
+      <p>Teacher Question:</p>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-18-1" data-id="p3r-april-18-1">
+      <label for="p3r-april-18-1">Answer: Middens</label>
 
-        <h4>[After School]</h4>
-        <p>*Note: Do not buy weapons*</p>
-        <p>Head to Iwatodai Strip Mall and buy Weird Takoyaki[400 Yen] from Octopia</p>
-        <p>Head to Paulownia Mall[Arcade] and play House of the Deceased[3000 Yen]</p>
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-18-2" data-id="p3r-april-18-2">
+      <label for="p3r-april-18-2">Social Link Fool Rank 1 [Automatic]</label>
+    </section>
 
-        <h4>[Evening]</h4>
-        <p>Head to Tartarus to activate the Dark Hour</p>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-19">Sunday April 19</h3>
+      <p>Nothing planned for this day.</p>
+    </section>
 
-        <h4>[Dark Hour]</h4>
-        <p>While in Tartarus complete the following</p>
-        <ul>
-          <li>Reach Floor 22</li>
-          <li>Make sure to reach level 11 or higher</li>
-          <li>Obtain enough materials to be sold for next day to acquire 40,000 Yen or more.(Make sure to create a save point before heading out of Tartarus to reload from incase enough materials was not received to sell.)</li>
-          <li>Obtain a Odd Morsel</li>
-          <li>Acquire Persona Forneus</li>
-          <li>Acquire Persona Pixie</li>
-          <li>Acquire Persona Silky</li>
-          <li>Acquire Persona Angel</li>
-          <li>Acquire Persona Apsaras</li>
-          <li>Fuse: Silky + Apsaras for Jack Frost</li>
-          <li>Fuse: Jack Frost + Angel or Opheus + Jack Frost for Omoikane</li>
-          <li>Fuse: Pixie + Jack Frost for Ara Mitama or Aquire Ara Mitama</li>
-        </ul>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-20">Monday April 20</h3>
+      <h4>[Dark Hour]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-20-1" data-id="p3r-april-20-1">
+      <label for="p3r-april-20-1">After Tartarus Tutorial: Social Link Fool Rank 2 [Automatic]</label>
+    </section>
 
-      <section>
-        <h3 class="" id="p3r-april-22">Wednesday April 22</h3>
-        <h3>Required Arcana: Magician</h3>
-        <h4>[After School]</h4>
-        <p>Social Link Magician Rank 1 [Automatic]</p>
 
-        <h4>[Evneing]</h4>
-        <p>Head to Paulowania Mall[Polica Station] to sell all materials.</p>
-        <p>*Make sure 40,000 Yen is acquired or more after selling materials, if not reload from previous save and farm for more materials.*</p>
-        <p>Head to Paulownia Mall[Mandragora] and Sing solo karaoke</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-21">Tuesday April 21</h3>
+      <h4>[Afternoon]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-21-1" data-id="p3r-april-21-1">
+      <label for="p3r-april-21-1">During Class: Stay Awake</label>
 
-      <section>
-        <h3 class="" id="p3r-april-23">Thursday April 23</h3>
-        <h3>Required Arcana: Chariot</h3>
-        <h4>[After School]</h4>
-        <p>Join Track Team</p>
-        <p>Location: Gekkoukan High School[Gym Hallway(Practice Field)]</p>
-        <p>Social Link Chariot Rank 1</p>
-        <ul>
-          <li>Choice: Any</li>
-          <li>Choice: Any</li>
-        </ul>
-        <p>Accept the event with Yuko</p>
-        <ul>
-          <li>Choice 1: Wanna walk home together?</li>
-        </ul>
+      <h4>[After School]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-21-2" data-id="p3r-april-21-2">
+      <label for="p3r-april-21-2">Head to Iwatodai Strip Mall and buy Weird Takoyaki [400 Yen] from Octopia</label>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-21-3" data-id="p3r-april-21-3">
+      <label for="p3r-april-21-3">Head to Paulownia Mall [Arcade] and play House of the Deceased [3000 Yen]</label>
 
-        <h4>[Evening]</h4>
-        <p>While in the dorm head to the 2F and buy Mad Bull [110 Yen] from the Vending Machine.</p>
-        <p>Head out to Paulownia Mall[Game Parade] and play High School of Youth [1500 Yen]</p>
-      </section>
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-21-4" data-id="p3r-april-21-4">
+      <label for="p3r-april-21-4">Head to Tartarus to activate the Dark Hour</label>
 
-      <section>
-        <h3 class="" id="p3r-april-24">Friday April 24</h3>
-        <h3>Required Arcana: Chariot, Strength</h3>
-        <h4>[After School]</h4>
-        <p>Social Link Chariot Rank 2</p>
-        <p>Location: Gekkoukan High School[Classroom 2-F]</p>
-        <ul>
-          <li>Choice 2: Toughen Up!</li>
-          <li>Choice: Any</li>
-          <li>Choice: Any</li>
-        </ul>
-        <p>Social Link Strength Rank 1</p>
-        <p>Accept the event with Yuko</p>
-        <p>Location: Unavailable</p>
-        <ul>
-          <li>Choice 1: Wanna walk home together?</li>
-          <li>Choice: Any</li>
-        </ul>
+      <h4>[Dark Hour]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-21-5" data-id="p3r-april-21-5">
+      <label for="p3r-april-21-5">While in Tartarus, complete the following tasks:</label>
+      <ul>
+        <li>Reach Floor 22</li>
+        <li>Make sure to reach level 11 or higher</li>
+        <li>Obtain enough materials to be sold for next day to acquire 40,000 Yen or more (Create a save point before
+          heading out of Tartarus to reload from in case enough materials were not received)</li>
+        <li>Obtain an Odd Morsel</li>
+        <li>Acquire Persona Forneus</li>
+        <li>Acquire Persona Pixie</li>
+        <li>Acquire Persona Silky</li>
+        <li>Acquire Persona Angel</li>
+        <li>Acquire Persona Apsaras</li>
+        <li>Fuse: Silky + Apsaras for Jack Frost</li>
+        <li>Fuse: Jack Frost + Angel or Orpheus + Jack Frost for Omoikane</li>
+        <li>Fuse: Pixie + Jack Frost for Ara Mitama or acquire Ara Mitama</li>
+      </ul>
+    </section>
 
-        <h4>[Evening]</h4>
-        <p>Head to Paulownia Mall[Game Parade] and play House of the Deceased[3000 Yen]</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-22">Wednesday April 22</h3>
+      <h3>Required Arcana: Magician</h3>
+      <h4>[After School]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-22-1" data-id="p3r-april-22-1">
+      <label for="p3r-april-22-1">Social Link Magician Rank 1 [Automatic]</label>
 
-      <section>
-        <h3 class="" id="p3r-april-25">Saturday April 25</h3>
-        <h3>Required Arcana: Hierophant</h3>
-        <h4>[After School]</h4>
-        <p>Head to Iwatodai Strip Mall[Bookworms] to start the prerequiste for Hirophant Social Link</p>
-        <p>Head to Gekkoukan High School[Corridor] and interact with the persimmon tree to obtain the persimmon leaf</p>
-        <p>Social Link Hierophant Rank 1</p>
-        <p>Head back to Iwatodai Strip Mall[Bookworms] and talk with the could couple to unlock Hierophant Social Link</p>
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-22-2" data-id="p3r-april-22-2">
+      <label for="p3r-april-22-2">Head to Paulownia Mall [Police Station] to sell all materials</label>
+      <p>*Make sure 40,000 Yen is acquired or more after selling materials, if not reload from previous save and farm
+        for more materials.*</p>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-22-3" data-id="p3r-april-22-3">
+      <label for="p3r-april-22-3">Head to Paulownia Mall [Mandragora] and Sing solo karaoke</label>
+    </section>
 
-        <h4>[Evening]</h4>
-        <p>Head to Paulownia Mall[Game Parade] and play You're the Answer [3000 Yen]</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-23">Thursday April 23</h3>
+      <h3>Required Arcana: Chariot</h3>
+      <h4>[After School]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-23-1" data-id="p3r-april-23-1">
+      <label for="p3r-april-23-1">Join Track Team</label>
+      <p>Location: Gekkoukan High School [Gym Hallway (Practice Field)]</p>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-23-2" data-id="p3r-april-23-2">
+      <label for="p3r-april-23-2">Social Link Chariot Rank 1</label>
+      <ul>
+        <li>Choice: Any</li>
+        <li>Choice: Any</li>
+      </ul>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-23-3" data-id="p3r-april-23-3">
+      <label for="p3r-april-23-3">Accept the event with Yuko</label>
+      <ul>
+        <li>Choice 1: Wanna walk home together?</li>
+      </ul>
 
-      <section>
-        <h3 class="" id="p3r-april-26">Sunday April 26</h3>
-        <h3>Required Arcana: Hierophant</h3>
-        <h4>[Daytime]</h4>
-        <p>Social Link Hierophant Rank 2</p>
-        <p>Location: Iwatodai Strip Mall[Bookwomrs]</p>
-        <ul>
-          <li>Choice 1: [Name]</li>
-          <li>Choice 1: Thank you</li>
-          <li>Choice: Any</li>
-          <li>Choice: Any</li>
-          <li>Choice: Any</li>
-        </ul>
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-23-4" data-id="p3r-april-23-4">
+      <label for="p3r-april-23-4">Head to the dorm, buy Mad Bull [110 Yen] from the vending machine on the 2nd
+        floor</label>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-23-5" data-id="p3r-april-23-5">
+      <label for="p3r-april-23-5">Head to Paulownia Mall [Game Parade] and play High School of Youth [1500 Yen]</label>
+    </section>
 
-        <h4>[Evening]</h4>
-        <p>Head to Iwatodai Strip Mall[Wild Duck Burger] and dine out there [1000 Yen].</p>
-      </section>
 
-      <section>
-        <h3 class="" id="p3r-april-27">Monday April 27</h3>
-        <h3>Required Arcana: Emperor</h3>
-        <h4>[Afternoon]</h4>
-        <p>Teacher Question:</p>
-        <p>A</p>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-24">Friday April 24</h3>
+      <h3>Required Arcana: Chariot, Strength</h3>
+      <h4>[After School]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-24-1" data-id="p3r-april-24-1">
+      <label for="p3r-april-24-1">Social Link Chariot Rank 2</label>
+      <p>Location: Gekkoukan High School [Classroom 2-F]</p>
+      <ul>
+        <li>Choice 2: Toughen Up!</li>
+        <li>Choice: Any</li>
+        <li>Choice: Any</li>
+      </ul>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-24-2" data-id="p3r-april-24-2">
+      <label for="p3r-april-24-2">Social Link Strength Rank 1</label>
+      <p>Accept the event with Yuko</p>
+      <ul>
+        <li>Choice 1: Wanna walk home together?</li>
+        <li>Choice: Any</li>
+      </ul>
 
-        <h4>[After School]</h4>
-        <p>Head to Gekkoukan High School[Faculty Office] and join the Student Council</p>
-        <p>Social Link Emperor Rank 1 [Automatic]</p>
-        <p>Location: Gekkoukan High School[Student Council Room]</p>
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-24-3" data-id="p3r-april-24-3">
+      <label for="p3r-april-24-3">Head to Paulownia Mall [Game Parade] and play House of the Deceased [3000 Yen]</label>
+    </section>
 
-        <h4>[Evening]</h4>
-        <p>Head to Iwatodai Strip Mall[Wakatsu Kitchen] to dine out there [680 Yen]</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-25">Saturday April 25</h3>
+      <h3>Required Arcana: Hierophant</h3>
+      <h4>[After School]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-25-1" data-id="p3r-april-25-1">
+      <label for="p3r-april-25-1">Head to Iwatodai Strip Mall [Bookworms] to start the prerequisite for Hierophant
+        Social Link</label>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-25-2" data-id="p3r-april-25-2">
+      <label for="p3r-april-25-2">Head to Gekkoukan High School [Corridor] and interact with the persimmon tree to
+        obtain the persimmon leaf</label>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-25-3" data-id="p3r-april-25-3">
+      <label for="p3r-april-25-3">Social Link Hierophant Rank 1</label>
+      <p>Head back to Iwatodai Strip Mall [Bookworms] and talk with the old couple to unlock Hierophant Social Link</p>
 
-      <section>
-        <h3 class="" id="p3r-april-28">Tuesday April 28</h3>
-        <h3>Required Arcana: Chariot</h3>
-        <h4>[After School]</h4>
-        <p>Head to F2 of Gekkoukan High School and talk to Chiriro</p>
-        <ul>
-          <li>Choice: I just wanted to talk...</li>
-        </ul>
-        <p>Social Link Chariot Rank 3</p>
-        <p>Location: Gekkoukan High School[Classroom]</p>
-        <ul>
-          <li>Choice 2: Are you going to be okay?</li>
-          <li>Choice 1: Will it heal?</li>
-        </ul>
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-25-4" data-id="p3r-april-25-4">
+      <label for="p3r-april-25-4">Head to Paulownia Mall [Game Parade] and play You're the Answer [3000 Yen]</label>
+    </section>
 
-        <h4>[Evening]</h4>
-        <p>head to Iwatodai Strip Mall[Wildduck Burger] and Dine Out [1000 Yen]</p>
-        <p>*Courange Rank Up - 2*</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-26">Sunday April 26</h3>
+      <h3>Required Arcana: Hierophant</h3>
+      <h4>[Daytime]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-26-1" data-id="p3r-april-26-1">
+      <label for="p3r-april-26-1">Social Link Hierophant Rank 2</label>
+      <p>Location: Iwatodai Strip Mall [Bookworms]</p>
+      <ul>
+        <li>Choice 1: [Name]</li>
+        <li>Choice 1: Thank you</li>
+        <li>Choice: Any</li>
+        <li>Choice: Any</li>
+        <li>Choice: Any</li>
+      </ul>
 
-      <section>
-        <h3 class="" id="p3r-april-29">Wednesday April 29</h3>
-        <h4>[Daytime]</h4>
-        <p>Social Link Hermit Rank 1 [Automatic]</p>
-        <p>Location: Dorm[Bedroom] </p>
-        <p>Play the MMORPG(Innocent Sin Online) to start the Hermit Social Link</p>
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-26-2" data-id="p3r-april-26-2">
+      <label for="p3r-april-26-2">Head to Iwatodai Strip Mall [Wild Duck Burger] and dine out there [1000 Yen]</label>
+    </section>
 
-        <h4>[Evening]</h4>
-        <p>While in the dorm, head to the Shared Computer on 1F and select Digital Cram School</p>
-      </section>
 
-      <section>
-        <h3 class="" id="p3r-april-30">Thursday April 30</h3>
-        <h3>Required Arcana: Hierophant</h3>
-        <h4>[Afternoon]</h4>
-        <p>Stay awake in class</p>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-27">Monday April 27</h3>
+      <h3>Required Arcana: Emperor</h3>
+      <h4>[Afternoon]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-27-1" data-id="p3r-april-27-1">
+      <label for="p3r-april-27-1">Teacher Question: Answer A</label>
 
-        <h4>[After School]</h4>
-        <p>Head to F2 of Gekkoukan High School and talk to Chiriro</p>
-        <ul>
-          <li>Choice: I'm a guy</li>
-        </ul>
+      <h4>[After School]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-27-2" data-id="p3r-april-27-2">
+      <label for="p3r-april-27-2">Head to Gekkoukan High School [Faculty Office] and join the Student Council</label>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-27-3" data-id="p3r-april-27-3">
+      <label for="p3r-april-27-3">Social Link Emperor Rank 1 [Automatic]</label>
+      <p>Location: Gekkoukan High School [Student Council Room]</p>
 
-        <p>Social Link Hierophant Rank 3</p>
-        <p>Location: Iwatodai Strip Mall[Bookwomrs]</p>
-        <ul>
-          <li>Choice 1: Looking for something?</li>
-          <li>Choice 2: Can I help?</li>
-          <li>Choice: Any</li>
-          <li>Choice: Any</li>
-          <li>Choice: Any</li>
-          <li>Choice: Any</li>
-        </ul>
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-27-4" data-id="p3r-april-27-4">
+      <label for="p3r-april-27-4">Head to Iwatodai Strip Mall [Wakatsu Kitchen] to dine out [680 Yen]</label>
+    </section>
 
-        <h4>[Evening]</h4>
-        <p>Head to Iwatodai Strip Mall[Net Cafe] and buy the following</p>
-        <ul>
-          <li>Lessons in Etiquette [1200 Yen]</li>
-          <li>Virtual Diet [1200 Yen]</li>
-          <li>Language Made Easy [1200 Yen]</li>
-          <li>Animal Othello [1200 Yen]</li>
-          <li>TypinGhoul [1200 Yen]</li>
-          <li>Muscle Boot Camp [2000 Yen]</li>
-          <li>Mindful Boot Camp [2000 Yen]</li>
-          <li>Umiushi Fan Book [450 Yen]</li>
-        </ul>
-        <p>Head to back to the Dorm and interact with the shared computer. Select Animal Orthello</p>
-      </section>
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-28">Tuesday April 28</h3>
+      <h3>Required Arcana: Chariot</h3>
+      <h4>[After School]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-28-1" data-id="p3r-april-28-1">
+      <label for="p3r-april-28-1">Head to 2F of Gekkoukan High School and talk to Chihiro</label>
+      <ul>
+        <li>Choice: I just wanted to talk...</li>
+      </ul>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-28-2" data-id="p3r-april-28-2">
+      <label for="p3r-april-28-2">Social Link Chariot Rank 3</label>
+      <p>Location: Gekkoukan High School [Classroom]</p>
+      <ul>
+        <li>Choice 2: Are you going to be okay?</li>
+        <li>Choice 1: Will it heal?</li>
+      </ul>
 
-      <section>
-        <table>
-          <h3>April Social Link Update</h3>
-          <thead>
-            <tr>
-              <th>Persona Arcana</th>
-              <th>Rank</th>
-              <th>Current Month Progress</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Fool(SEES)</td>
-              <td>2</td>
-              <td>New, Rank UP +2</td>
-            </tr>
-            <tr>
-              <td>Magician(Classmate)</td>
-              <td>1</td>
-              <td>New, Rank Up +1</td>
-            </tr>
-            <tr>
-              <td>Emperor</td>
-              <td>1</td>
-              <td>New, Rank Up +1</td>
-            </tr>
-            <tr>
-              <td>Hierophant(Old Couple)</td>
-              <td>3</td>
-              <td>New, Rank Up +3</td>
-            </tr>
-            <tr>
-              <td>Chariot(Track Team)</td>
-              <td>3</td>
-              <td>New, Rank Up +3</td>
-            </tr>
-            <tr>
-              <td>Hermit(Online Game)</td>
-              <td>1</td>
-              <td>New, Rank Up +1</td>
-            </tr>
-            <tr>
-              <td>Strength(Team Manager)</td>
-              <td>1</td>
-              <td>New, Rank Up +1</td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-28-3" data-id="p3r-april-28-3">
+      <label for="p3r-april-28-3">Head to Iwatodai Strip Mall [Wild Duck Burger] and dine out [1000 Yen]</label>
+      <p>*Courage Rank Up - 2*</p>
+    </section>
+
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-29">Wednesday April 29</h3>
+      <h4>[Daytime]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-29-1" data-id="p3r-april-29-1">
+      <label for="p3r-april-29-1">Social Link Hermit Rank 1 [Automatic]</label>
+      <p>Location: Dorm [Bedroom]</p>
+      <p>Play the MMORPG (Innocent Sin Online) to start the Hermit Social Link</p>
+
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-29-2" data-id="p3r-april-29-2">
+      <label for="p3r-april-29-2">While in the dorm, head to the Shared Computer on 1F and select Digital Cram
+        School</label>
+    </section>
+
+    <section class="daily-content">
+      <h3 class="date-font" id="p3r-april-30">Thursday April 30</h3>
+      <h3>Required Arcana: Hierophant</h3>
+      <h4>[Afternoon]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-30-1" data-id="p3r-april-30-1">
+      <label for="p3r-april-30-1">Stay awake in class</label>
+
+      <h4>[After School]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-30-2" data-id="p3r-april-30-2">
+      <label for="p3r-april-30-2">Head to 2F of Gekkoukan High School and talk to Chihiro</label>
+      <ul>
+        <li>Choice: I'm a guy</li>
+      </ul>
+
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-30-3" data-id="p3r-april-30-3">
+      <label for="p3r-april-30-3">Social Link Hierophant Rank 3</label>
+      <p>Location: Iwatodai Strip Mall [Bookworms]</p>
+      <ul>
+        <li>Choice 1: Looking for something?</li>
+        <li>Choice 2: Can I help?</li>
+        <li>Choice: Any</li>
+        <li>Choice: Any</li>
+        <li>Choice: Any</li>
+        <li>Choice: Any</li>
+      </ul>
+
+      <h4>[Evening]</h4>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-30-4" data-id="p3r-april-30-4">
+      <label for="p3r-april-30-4">Head to Iwatodai Strip Mall [Net Cafe] and buy the following:</label>
+      <ul>
+        <li>Lessons in Etiquette [1200 Yen]</li>
+        <li>Virtual Diet [1200 Yen]</li>
+        <li>Language Made Easy [1200 Yen]</li>
+        <li>Animal Othello [1200 Yen]</li>
+        <li>TypinGhoul [1200 Yen]</li>
+        <li>Muscle Boot Camp [2000 Yen]</li>
+        <li>Mindful Boot Camp [2000 Yen]</li>
+        <li>Umiushi Fan Book [450 Yen]</li>
+      </ul>
+      <input type="checkbox" class="progress-checkbox" id="p3r-april-30-5" data-id="p3r-april-30-5">
+      <label for="p3r-april-30-5">Head back to the Dorm and interact with the shared computer. Select Animal
+        Othello</label>
+    </section>
+
+
+    <section>
+      <table class="confidant-table">
+        <h3>April Social Link Update</h3>
+        <thead>
+          <tr>
+            <th>Persona Arcana</th>
+            <th>Rank</th>
+            <th>Current Month Progress</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Fool(SEES)</td>
+            <td>2</td>
+            <td>New, Rank UP +2</td>
+          </tr>
+          <tr>
+            <td>Magician(Classmate)</td>
+            <td>1</td>
+            <td>New, Rank Up +1</td>
+          </tr>
+          <tr>
+            <td>Emperor</td>
+            <td>1</td>
+            <td>New, Rank Up +1</td>
+          </tr>
+          <tr>
+            <td>Hierophant(Old Couple)</td>
+            <td>3</td>
+            <td>New, Rank Up +3</td>
+          </tr>
+          <tr>
+            <td>Chariot(Track Team)</td>
+            <td>3</td>
+            <td>New, Rank Up +3</td>
+          </tr>
+          <tr>
+            <td>Hermit(Online Game)</td>
+            <td>1</td>
+            <td>New, Rank Up +1</td>
+          </tr>
+          <tr>
+            <td>Strength(Team Manager)</td>
+            <td>1</td>
+            <td>New, Rank Up +1</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
     <!--</section>-->
-  </main>
+</main>
+
 </html>

--- a/Persona3reload/persona3reload.html
+++ b/Persona3reload/persona3reload.html
@@ -3,26 +3,24 @@
   <head>
     <title>Persona 3 Reload Guide</title>
     <link href="/css/p3r-main-page.css" rel="stylesheet" />
-    <link />
   </head>
-  <main>
-    <header>
-      <!-- Need a header image-->
-      <h1><img src="" alt="" />Persona 3 Reload</h1>
-      <nav>
-        <h3><a href="/Persona3reload/calendar-p3r.html">Calendar</a></h3>
-        <!--<h3><a href="">Confidants</a></h3>-->
-      </nav>
-    </header>
-    <section>
-      <h3>Guide to this Walkthrough for Persona 3 Reload Edition</h3>
-      <h4>
-        Note: This walk through is for Persona 3 Reload. If playing Persona 3,
-        Persona 3 FES, or Persona 3 Portable(P3P) this guide will not be the
-        best option to follow along with.
-      </h4>
-    </section>
-
-    <!--<section></section>-->
-  </main>
+  <body>
+    <main>
+      <header>
+        <h1>Persona 3 Reload</h1>
+        <nav>
+          <h3><a href="/Persona3reload/calendar-p3r.html">Calendar</a></h3>
+          <!--<h3><a href="">Confidants</a></h3>-->
+        </nav>
+      </header>
+      <section>
+        <h3>Guide to this Walkthrough for Persona 3 Reload Edition</h3>
+        <h4>
+          Note: This walk through is for Persona 3 Reload. If playing Persona 3,
+          Persona 3 FES, or Persona 3 Portable(P3P) this guide will not be the
+          best option to follow along with.
+        </h4>
+      </section>
+    </main>
+  </body>
 </html>

--- a/css/p3r-calendar-page.css
+++ b/css/p3r-calendar-page.css
@@ -1,61 +1,59 @@
-/*@font-face {
-    font-family: Persona5MenuFontPrototype;
-    src: url(/css/fonts/Persona5MenuFontPrototype-Regular.ttf);
-  }
-  
-  @font-face {
-    font-family: p5hatty;
-    src: url(/css/fonts/p5hatty.ttf);
-  }
-  */
-  main {
-    border: 5px solid #FFFFFF;
-  }
-  
-  h1 {
-    font-size: 60px;
-    text-align: center;
-    color: black;
-    border-bottom: 5px solid #FFFFFF;
-    padding: 10px;
-  }
-  
-  body {
-    background-color: #4682B4;
-  }
-  
-  nav {
-    position: relative;
-    width: 180px;
-    float: inline-start;
-    padding: 10px;
-    /*border-right: 5px solid black;
-      border-top: 5px solid black;
-      border-bottom: 5px solid black;*/
-  }
-  
-  nav h3 {
-    width: 120px;
-    /*float:left;*/
-    margin-left: 2px;
-    border: 5px solid #FFFFFF;
-  }
-  
-  nav a {
-    display: block;
-    padding: 3px;
-    text-decoration: none;
-    background-color: #fff;
-    color: black;
-  }
-  
-  /*------------------------------------------------*/
-  /*all action based css commands below this comment*/
-  /*------------------------------------------------*/
-  
-  /*changes the color of the list items when hovered over*/
-  nav a:hover {
-    background-color: #4682B4;
-    color: #fff;
-  }
-  
+/* Body Styling */
+body {
+  background-color: #1B2838; /* Dark blue background */
+  color: #E0E6ED; /* Light text color */
+  font-family: 'Arial', sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+/* Main Container */
+main {
+  border: 5px solid #3A506B; /* Blue-gray border */
+  margin: 20px auto;
+  padding: 20px;
+  max-width: 1200px;
+  background-color: #273D56; /* Slightly lighter blue for contrast */
+  border-radius: 10px;
+}
+
+/* Header Styling */
+header h1 {
+  font-size: 50px;
+  text-align: center;
+  color: #00A1E4; /* Bright blue for the title */
+  border-bottom: 3px solid #3A506B;
+  padding-bottom: 10px;
+  margin-bottom: 20px;
+}
+
+/* Navigation Menu */
+nav {
+  width: 200px;
+  margin: 0 auto;
+  padding: 10px;
+  background-color: #1B2838; /* Darker background for the nav */
+  border-radius: 5px;
+}
+
+nav h3 {
+  margin: 10px 0;
+  border: 2px solid #3A506B;
+  text-align: center;
+  border-radius: 5px;
+}
+
+nav a {
+  display: block;
+  padding: 10px 15px;
+  text-decoration: none;
+  background-color: #273D56; /* Matches main content background */
+  color: #E0E6ED;
+  font-size: 18px;
+  border-radius: 5px;
+}
+
+nav a:hover {
+  background-color: #00A1E4; /* Bright blue hover effect */
+  color: #E0E6ED;
+}

--- a/css/p3r-main-page.css
+++ b/css/p3r-main-page.css
@@ -1,77 +1,77 @@
-/*@font-face {
-    font-family: Persona5MenuFontPrototype;
-    src: url(/css/fonts/Persona5MenuFontPrototype-Regular.ttf);
-  }
-  
-  @font-face {
-    font-family: p5hatty;
-    src: url(/css/fonts/p5hatty.ttf);
-  }
-  */
-  main {
-    border: 5px solid #FFFFFF;
-  }
-  
-  h1 {
-    font-size: 60px;
-    text-align: center;
-    color: black;
-    border-bottom: 5px solid #FFFFFF;
-    padding: 10px;
-  }
-  
-  body {
-    background-color: #4682B4;
-  }
-  
-  section {
-    position: inherit;
-    align-items: center;
-    background-color: #4682B4;
-    border: 5px solid #FFFFFF;
-    border-style: outset;
-  }
-  
-  nav {
-    position: fixed;
-    margin-top: -60px;
-    width: 180px;
-    float: left;
-    padding: 10px;
-    /*border-right: 5px solid black;
-      border-top: 5px solid black;
-      border-bottom: 5px solid black;*/
-  }
-  
-  nav a {
-    display: block;
-    padding: 3px;
-    text-decoration: none;
-    background-color: #fff;
-    color: black;
-  }
-  
-  h3 {
-    color: White;
-    text-align: center;
-  }
-  
-  h4 {
-    color: white;
-    text-align: center;
-    font-weight: bold;
-  }
-  
-  h5 {
-    font-family: "Bubblegum Superstar";
-    font-size: 25px;
-    font-weight: bold;
-    text-align: center;
-    color: white;
-  }
-  
-  p {
-    color: white;
-    text-align: center;
-  }
-  
+/* Body Styling */
+body {
+  background-color: #1B2838; /* Dark blue background */
+  color: #E0E6ED; /* Light text color */
+  font-family: 'Arial', sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+/* Main Styling */
+main {
+  margin: 20px auto;
+  padding: 20px;
+  border: 5px solid #3A506B;
+  border-radius: 10px;
+  background-color: #273D56; /* Slightly lighter blue for contrast */
+  max-width: 1200px;
+}
+
+/* Header Styling */
+header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+header h1 {
+  font-size: 50px;
+  color: #00A1E4; /* Bright blue for the title */
+  border-bottom: 2px solid #3A506B;
+  padding-bottom: 10px;
+}
+
+header nav {
+  margin-top: 20px;
+  padding: 10px;
+  background-color: #1B2838;
+  border-radius: 5px;
+  display: inline-block;
+}
+
+header nav h3 {
+  margin: 0;
+}
+
+header nav a {
+  text-decoration: none;
+  color: #E0E6ED;
+  padding: 10px 15px;
+  display: inline-block;
+  font-size: 18px;
+  background-color: #273D56;
+  margin-right: 10px;
+  border-radius: 5px;
+}
+
+header nav a:hover {
+  background-color: #00A1E4; /* Bright blue for hover */
+}
+
+/* Section Styling */
+section {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: #1B2838;
+  border: 2px solid #3A506B;
+  border-radius: 10px;
+}
+
+section h3, section h4 {
+  color: #E0E6ED;
+  text-align: center;
+}
+
+section p {
+  color: #B0BEC5; /* Slightly lighter color for text */
+  text-align: center;
+}

--- a/css/p3r-months.css
+++ b/css/p3r-months.css
@@ -1,189 +1,170 @@
-/*@font-face {
-    font-family: Persona5MenuFontPrototype;
-    src: url(/css/fonts/Persona5MenuFontPrototype-Regular.ttf);
-  }
-  
-  @font-face {
-    font-family: p5hatty;
-    src: url(/css/fonts/p5hatty.ttf);
-  }*/
-  
-  /*creates a border around main page*/
-  main {
-    border: 5px solid #FFFFFF;
-  }
-  
-  h1 {
-    font-family: "Persona5MenuFontPrototype";
-    font-size: 60px;
-    text-align: center;
-    color: black;
-    border-bottom: 5px solid #FFFFFF;
-    padding: 10px;
-  }
-  
-  body {
-    background-color: #4682B4;
-  }
-  
-  /*basically removes dots from list*/
-  .main_menu_style {
-    list-style: none;
-  }
-  
-  /*sets the placement of the nav menu and adds a border around it*/
-  #main_menu_setup {
-    position: fixed;
-    width: 180px;
-    float: left;
-    padding: 10px;
-    border-right: 5px solid #FFFFFF;
-    border-top: 5px solid #FFFFFF;
-    border-bottom: 5px solid #FFFFFF;
-  }
-  
-  /*adds border around the list items*/
-  #main_menu_setup li {
-    width: 120px;
-    float: left;
-    margin-left: 2px;
-    border: 5px solid #FFFFFF;
-  }
-  
-  /*helps mimick the list items as buttons*/
-  #main_menu_setup a {
-    display: block;
-    padding: 3px;
-    text-decoration: none;
-    background-color: #fff;
-    color: black;
-  }
-  
-  /*sets position of nav calendar*/
-  #cal_nav {
-    position: fixed;
-    top: 310px;
-    width: 180px;
-    float: left;
-    padding: 10px;
-    border-right: 5px solid #FFFFFF;
-    border-top: 5px solid #FFFFFF;
-    border-bottom: 5px solid #FFFFFF;
-  }
-  
-  .cal_nav_font a {
-    text-decoration: none;
-    color: black;
-  }
-  .cal_nav_border,
-  .cal_nav_th_font,
-  .cal_nav_font {
-    border: 5px solid #FFFFFF;
-  }
-  
-  section {
-    align-items: center;
-    background-color: #4682B4;
-    border: 5px solid #FFFFFF;
-    border-style: outset;
-  }
-  
-  #content-days {
-    margin-left: 400px;
-    border-left: 2px solid FFFFFF;
-    padding: 10px;
-    line-height: 2em;
-  }
-  
-  h3 {
-    font-family: "Bubblegum Superstar";
-    font-size: 25px;
-    font-weight: bold;
-    text-align: center;
-    color: black;
-  }
-  
-  h3.date-font {
-    font-family: "Persona5MenuFontPrototype";
-    font-weight: bolder;
-    text-align: center;
-    font-size: 30px;
-    font-style: italic;
-    color: black;
-    text-decoration: underline;
-  }
-  
-  h4 {
-    font-family: "p5hatty";
-    font-size: 20px;
-    font-weight: bold;
-    text-align: center;
-    color: black;
-  }
-  p {
-    font-family: "Arsenal";
-    font-size: 16px;
-    text-align: center;
-    color: black;
-  }
-  .p5r-romance {
-    color: #d62e2e;
-  }
-  
-  ol {
-    list-style-position: inside;
-    font-family: "Arsenal";
-    font-size: 16px;
-    text-align: center;
-    color: black;
-  }
-  
-  ul {
-    list-style-position: inside;
-    font-family: "Arsenal";
-    font-size: 16px;
-    text-align: center;
-    color: black;
-  }
-  
-  table,
-  th,
-  td {
-    border: 5px solid #FFFFFF;
-  }
-  
-  table {
-    border-collapse: collapse;
-    margin-left: auto;
-    margin-right: auto;
-  }
-  
-  th {
-    font-family: "Arsenal";
-    font-size: 16px;
-    font-weight: bold;
-    text-align: center;
-    color: white;
-  }
-  
-  td {
-    font-family: "Arsenal";
-    font-size: 16px;
-    text-align: center;
-    color: black;
-  }
-  /*------------------------------------------------*/
-  /*all action based css commands below this comment*/
-  /*------------------------------------------------*/
-  
-  /*changes the color of the list items when hovered over*/
-  #main_menu_setup a:hover {
-    background-color: black;
-    color: #fff;
-  }
-  
-  .cal_nav_font a:hover {
-    background-color: black;
-    color: #FFFFFF;
-  }
-  
+/* p3r-months.css */
+
+/* Body and General Styling */
+body {
+  font-family: 'Arial', sans-serif;
+  background-color: #2C3E50; /* Dark blue background */
+  color: #ECF0F1; /* Light text color */
+  margin: 0;
+  padding: 0;
+}
+
+/* Header Styling */
+header {
+  background-color: #1A252F; /* Darker shade for header */
+  color: #ECF0F1; /* Light text color */
+  text-align: center;
+  padding: 20px 0;
+  font-size: 26px;
+  font-weight: bold;
+}
+
+header nav ul {
+  list-style-type: none;
+  padding: 0;
+  margin: 10px 0;
+}
+
+header nav ul li {
+  display: inline;
+  margin-right: 15px;
+}
+
+header nav ul li a {
+  color: #ECF0F1;
+  text-decoration: none;
+  font-size: 18px;
+  font-weight: normal;
+}
+
+header nav ul li a:hover {
+  color: #2980B9;
+}
+
+/* Navigation Menu */
+.navbar {
+  overflow: hidden;
+  background-color: #34495E; /* Dark blue-gray for navbar */
+}
+
+.navbar a {
+  float: left;
+  display: block;
+  color: #ECF0F1;
+  text-align: center;
+  padding: 14px 20px;
+  text-decoration: none;
+  font-size: 18px;
+}
+
+.navbar a:hover {
+  background-color: #2980B9; /* Highlight on hover */
+  color: #ECF0F1;
+}
+
+/* Calendar Styling */
+table.cal_nav_border {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+
+table.cal_nav_border th,
+table.cal_nav_border td {
+  border: 1px solid #1A252F;
+  padding: 10px;
+  text-align: center;
+  color: #ECF0F1;
+}
+
+table.cal_nav_border th {
+  background-color: #34495E;
+  font-size: 18px;
+}
+
+table.cal_nav_border td {
+  background-color: #2C3E50;
+  font-size: 16px;
+}
+
+table.cal_nav_border td a {
+  color: #ECF0F1;
+  text-decoration: none;
+}
+
+table.cal_nav_border td a:hover {
+  color: #2980B9;
+}
+
+table.cal_nav_border td:hover {
+  background-color: #2980B9;
+}
+
+/* Daily Content Section */
+.daily-content {
+  margin: 20px;
+  padding: 15px;
+  background-color: #1A252F;
+  border-radius: 10px;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.daily-content h3 {
+  color: #ECF0F1;
+  font-size: 20px;
+}
+
+.daily-content p {
+  color: #BDC3C7;
+  font-size: 16px;
+}
+
+.daily-content input[type="checkbox"] {
+  transform: scale(1.2);
+  margin-right: 10px;
+}
+
+/* Confidant Table */
+.confidant-table {
+  width: 100%;
+  margin: 20px 0;
+  border-collapse: collapse;
+  background-color: #34495E;
+  color: #ECF0F1;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.confidant-table th, .confidant-table td {
+  padding: 12px 15px;
+  text-align: left;
+  border-bottom: 1px solid #1A252F;
+}
+
+.confidant-table th {
+  background-color: #2980B9;
+  color: #ECF0F1;
+  font-weight: bold;
+}
+
+.confidant-table tr:hover {
+  background-color: #2980B9;
+}
+
+/* Button Styling */
+.button {
+  background-color: #2980B9;
+  color: #ECF0F1;
+  padding: 10px 20px;
+  text-align: center;
+  border: none;
+  border-radius: 5px;
+  font-size: 16px;
+  cursor: pointer;
+  margin: 10px 0;
+}
+
+.button:hover {
+  background-color: #1A252F;
+  color: #ECF0F1;
+}


### PR DESCRIPTION
Main Page (Persona 3 Reload Guide):

Header & Navigation: Updated the header to include a bold title with a dark blue background and bright blue accents, aligning with the Persona 3 Reload theme. Enhanced the navigation links with consistent styling that complements the overall aesthetic. Body & Section Styling: Applied a dark blue background to the main content area with light text, creating a sleek and modern look. The sections were given subtle borders and padding to improve readability and structure. Month Selection Page:

Header: Similar to the main page, the header was styled with a bold title and a dark background. A subtle border was added to enhance the design.
Navigation Menu: The month selection links were updated to match the Persona 3 Reload theme. The links were styled with a dark background, light text, and hover effects that bring a bright blue highlight.
Overall Layout: Ensured that the layout was clean and cohesive, with consistent padding, borders, and colors that align with the game's dark and moody aesthetic.